### PR TITLE
Ag water change overdue

### DIFF
--- a/src/components/aquariumhistory/AquariumHistoryForm.js
+++ b/src/components/aquariumhistory/AquariumHistoryForm.js
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useState } from "react"
-import { useParams } from "react-router-dom"
 import { AquariumHistoryContext } from "./AquariumHistoryProvider"
 import { Container, Form } from "semantic-ui-react"
+import { Icon } from "semantic-ui-react"
 import "./AquariumHistory.css"
 
 export const AquariumHistoryForm = props => {
@@ -11,8 +11,6 @@ export const AquariumHistoryForm = props => {
     const [isLoading, setIsLoading] = useState(true)
 
     const aquariumId = parseInt(window.location.pathname.split("/").pop())
-
-    const { aquariumHistoryId } = useParams()
 
     const handleControlledInputChange = (evt) => {
         const newAquariumHistory = { ...aquariumHistory }
@@ -60,6 +58,13 @@ export const AquariumHistoryForm = props => {
     return (
         <Container className="aquariumHistoryFormContainer">
             <h3 className="fishForm_title">{props.aquariumHistoryId ? "Edit Water Change" : "Log Water Change"}</h3>
+
+            { props.warningTime === true ?
+
+                <span><Icon name="warning sign" color="red" /> <strong style={{ color: "red" }}>It's been more than two weeks
+            since you're last water change</strong></span>
+
+                : ""}
 
             <Form className="aquariumHistoryForm" onSubmit={evt => {
                 evt.preventDefault()
@@ -151,6 +156,6 @@ export const AquariumHistoryForm = props => {
                     Save
                 </Form.Button>
             </Form>
-        </Container>
+        </Container >
     )
 }

--- a/src/components/aquariumhistory/AquariumHistoryList.js
+++ b/src/components/aquariumhistory/AquariumHistoryList.js
@@ -20,6 +20,8 @@ export const AquariumHistoryList = () => {
     const currentAquariumHistory = aquariumHistory.filter(obj => obj.aquariumId === aquariumId)
     const reversedAquariumHistory = currentAquariumHistory.reverse()
 
+    let warningTime = false
+
     // focus on the most recent water change
     const mostRecentObj = reversedAquariumHistory[0]
 
@@ -34,14 +36,14 @@ export const AquariumHistoryList = () => {
         const twoWeeks = 1209600000 // two weeks in milliseconds
 
         if (timeGap > twoWeeks) {
-            console.log("Time for a water change!")
+            warningTime = true
         }
     }
 
     return (
         <>
             <Container className="aquariumHistory">
-                <AquariumHistoryForm />
+                <AquariumHistoryForm warningTime={warningTime} />
 
                 {currentAquariumHistory.length > 0 ? <h3>Water Quality History</h3> : ""}
                 <Card.Group>

--- a/src/components/aquariumhistory/AquariumHistoryList.js
+++ b/src/components/aquariumhistory/AquariumHistoryList.js
@@ -20,6 +20,11 @@ export const AquariumHistoryList = () => {
     const currentAquariumHistory = aquariumHistory.filter(obj => obj.aquariumId === aquariumId)
     const reversedAquariumHistory = currentAquariumHistory.reverse()
 
+    const today = Date.now()
+    const mostRecentObj = reversedAquariumHistory[0]
+
+    console.log(mostRecentObj)
+
     return (
         <>
             <Container className="aquariumHistory">

--- a/src/components/aquariumhistory/AquariumHistoryList.js
+++ b/src/components/aquariumhistory/AquariumHistoryList.js
@@ -20,10 +20,23 @@ export const AquariumHistoryList = () => {
     const currentAquariumHistory = aquariumHistory.filter(obj => obj.aquariumId === aquariumId)
     const reversedAquariumHistory = currentAquariumHistory.reverse()
 
-    const today = Date.now()
+    // focus on the most recent water change
     const mostRecentObj = reversedAquariumHistory[0]
 
-    console.log(mostRecentObj)
+    // setting up date test to see if last water change was more than two weeks ago
+    let mostRecentDate
+    if (mostRecentObj !== undefined) {
+        const today = Date.now()
+        mostRecentDate = mostRecentObj.testDate // date from most recent water change
+        const mostRecentParse = Date.parse(mostRecentDate) // parsing that date
+
+        const timeGap = today - mostRecentParse // time gap in milliseconds
+        const twoWeeks = 1209600000 // two weeks in milliseconds
+
+        if (timeGap > twoWeeks) {
+            console.log("Time for a water change!")
+        }
+    }
 
     return (
         <>


### PR DESCRIPTION
This PR is to test overdue water change warning functionality.

- [x] If a water change was performed over two weeks ago, a warning should appear on the form
- [x] Logging a new change (that is now less than two weeks ago) should clear the warning